### PR TITLE
Added @objc to coordinatingResponder for Swift4 compatibility

### DIFF
--- a/Coordinator.swift
+++ b/Coordinator.swift
@@ -193,7 +193,7 @@ At the UIViewController level (see below), it‘s intercepted to switch up to th
 Once that happens, it stays in the Coordinator hierarchy, since coordinator can be nested only inside other coordinators.
 */
 public extension UIResponder {
-	public var coordinatingResponder: UIResponder? {
+	@objc public var coordinatingResponder: UIResponder? {
 		return next
 	}
 


### PR DESCRIPTION
Swift 4 removes @objc inference and forces you to make explicit any method or property that needs dynamic dispatch. 

Source:
https://github.com/apple/swift-evolution/blob/master/proposals/0160-objc-inference.md

Without the explicit @objc the following error would appear (Tested on Xcode 9 beta 5) :
`error: declarations from extensions cannot be overridden yet`

You can test the error by adding Coordinator.swift file to a newly created Xcode 9 Swift 4 project.
