### PR TITLE
Fixed memory leak in associated object property parentCoordinator

### DIFF
--- a/Coordinator.swift
+++ b/Coordinator.swift
@@ -170,12 +170,12 @@ extension UIViewController {
 		static var ParentCoordinator = "ParentCoordinator"
 	}
 
-	public var parentCoordinator: Coordinating? {
+	public weak var parentCoordinator: Coordinating? {
 		get {
 			return objc_getAssociatedObject(self, &AssociatedKeys.ParentCoordinator) as? Coordinating
 		}
 		set {
-			objc_setAssociatedObject(self, &AssociatedKeys.ParentCoordinator, newValue, .OBJC_ASSOCIATION_RETAIN)
+			objc_setAssociatedObject(self, &AssociatedKeys.ParentCoordinator, newValue, .OBJC_ASSOCIATION_ASSIGN)
 		}
 	}
 }


### PR DESCRIPTION
Fixed retain cycle where a coordinator strongly references a rootViewController and the rootViewController has a strong circular reference back to parent coordinator.

`OBJC_ASSOCIATION_RETAIN` policy creates a strong reference. Since a UIViewController is the child of a coordinator it should have a weak reference to it's parent using `OBJC_ASSOCIATION_ASSIGN`. Although `OBJC_ASSOCIATION_ASSIGN` is non-zeroing and works like Objective-C `unsafe_unretained` it should work well enough to allow the UIViewController to be deallocated properly.

Source: http://nshipster.com/associated-objects/