### PR TITLE
Fix typo in NavigationCoordinator

### DIFF
--- a/Coordinator/NavigationCoordinator.swift
+++ b/Coordinator/NavigationCoordinator.swift
@@ -112,7 +112,7 @@ private extension NavigationCoordinator {
 		guard let fromViewController = fromViewController else { return }
 
 		//	if this FROM controller is not in the Coordinator's internal list, ignore it
-		if !viewControllers.contains( viewController ) { return }
+		if !viewControllers.contains(fromViewController) { return }
 
 		//	check is this pop:
 		if let vc = self.viewControllers.last, vc === fromViewController {


### PR DESCRIPTION
The check in didShowController is in order to check whether we are popping the coordinator. But the code is checking if the `viewController` we are moving to is in our list of `viewControllers`. This will never be the case for popping the coordinator.