### PR TITLE
Fix non-animated & multiple pop handling

### DIFF
--- a/Coordinator.xcodeproj/project.pbxproj
+++ b/Coordinator.xcodeproj/project.pbxproj
@@ -117,7 +117,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		33048BBB21FA6F8A00B93597 /* ExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		33048BBD21FA6F8A00B93597 /* NavigationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationCoordinatorTests.swift; sourceTree = "<group>"; };
+		33048BBF21FA6F8A00B93597 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D00541721F46349500CFF7AE /* Embeddable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Embeddable.swift; sourceTree = "<group>"; };
 		D00541731F46349500CFF7AE /* StoryboardLoadable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoryboardLoadable.swift; sourceTree = "<group>"; };
 		D00541751F46349500CFF7AE /* Bundle-Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Bundle-Extensions.swift"; sourceTree = "<group>"; };

--- a/Coordinator.xcodeproj/project.pbxproj
+++ b/Coordinator.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		33048BBE21FA6F8A00B93597 /* NavigationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33048BBD21FA6F8A00B93597 /* NavigationCoordinatorTests.swift */; };
 		D00541801F46349500CFF7AE /* Embeddable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D00541721F46349500CFF7AE /* Embeddable.swift */; };
 		D00541811F46349500CFF7AE /* StoryboardLoadable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D00541731F46349500CFF7AE /* StoryboardLoadable.swift */; };
 		D00541821F46349500CFF7AE /* Bundle-Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D00541751F46349500CFF7AE /* Bundle-Extensions.swift */; };
@@ -85,6 +86,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		33048BC021FA6F8A00B93597 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D04B76541DE5B6D2009F1B9A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D04B765B1DE5B6D2009F1B9A;
+			remoteInfo = Example;
+		};
 		D0A788CA21E25679002F34B2 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D04B76541DE5B6D2009F1B9A /* Project object */;
@@ -109,6 +117,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		33048BBD21FA6F8A00B93597 /* NavigationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationCoordinatorTests.swift; sourceTree = "<group>"; };
 		D00541721F46349500CFF7AE /* Embeddable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Embeddable.swift; sourceTree = "<group>"; };
 		D00541731F46349500CFF7AE /* StoryboardLoadable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoryboardLoadable.swift; sourceTree = "<group>"; };
 		D00541751F46349500CFF7AE /* Bundle-Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Bundle-Extensions.swift"; sourceTree = "<group>"; };
@@ -190,6 +199,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		33048BB821FA6F8A00B93597 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D04B76591DE5B6D2009F1B9A /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -212,6 +228,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		33048BBC21FA6F8A00B93597 /* ExampleTests */ = {
+			isa = PBXGroup;
+			children = (
+				33048BBD21FA6F8A00B93597 /* NavigationCoordinatorTests.swift */,
+				33048BBF21FA6F8A00B93597 /* Info.plist */,
+			);
+			path = ExampleTests;
+			sourceTree = "<group>";
+		};
 		771A0BD9B13E86050EF52F25 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -352,6 +377,7 @@
 				D06488D921D0FA8F00F3F0E7 /* README.md */,
 				D005416F1F4633A200CFF7AE /* Vendor */,
 				D04B765E1DE5B6D2009F1B9A /* App */,
+				33048BBC21FA6F8A00B93597 /* ExampleTests */,
 				D0A788C621E25679002F34B2 /* Framework */,
 				D04B765D1DE5B6D2009F1B9A /* Products */,
 				771A0BD9B13E86050EF52F25 /* Frameworks */,
@@ -363,6 +389,7 @@
 			children = (
 				D04B765C1DE5B6D2009F1B9A /* Example.app */,
 				D0A788C521E25679002F34B2 /* Coordinator.framework */,
+				33048BBB21FA6F8A00B93597 /* ExampleTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -504,6 +531,24 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		33048BBA21FA6F8A00B93597 /* ExampleTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 33048BC421FA6F8A00B93597 /* Build configuration list for PBXNativeTarget "ExampleTests" */;
+			buildPhases = (
+				33048BB721FA6F8A00B93597 /* Sources */,
+				33048BB821FA6F8A00B93597 /* Frameworks */,
+				33048BB921FA6F8A00B93597 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				33048BC121FA6F8A00B93597 /* PBXTargetDependency */,
+			);
+			name = ExampleTests;
+			productName = ExampleTests;
+			productReference = 33048BBB21FA6F8A00B93597 /* ExampleTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		D04B765B1DE5B6D2009F1B9A /* Example */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = D04B766E1DE5B6D2009F1B9A /* Build configuration list for PBXNativeTarget "Example" */;
@@ -552,6 +597,11 @@
 				LastUpgradeCheck = 0940;
 				ORGANIZATIONNAME = "Radiant Tap";
 				TargetAttributes = {
+					33048BBA21FA6F8A00B93597 = {
+						CreatedOnToolsVersion = 10.0;
+						ProvisioningStyle = Automatic;
+						TestTargetID = D04B765B1DE5B6D2009F1B9A;
+					};
 					D04B765B1DE5B6D2009F1B9A = {
 						CreatedOnToolsVersion = 8.1;
 						LastSwiftMigration = 1000;
@@ -578,11 +628,19 @@
 			targets = (
 				D04B765B1DE5B6D2009F1B9A /* Example */,
 				D0A788C421E25679002F34B2 /* Coordinator */,
+				33048BBA21FA6F8A00B93597 /* ExampleTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		33048BB921FA6F8A00B93597 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D04B765A1DE5B6D2009F1B9A /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -632,6 +690,14 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		33048BB721FA6F8A00B93597 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				33048BBE21FA6F8A00B93597 /* NavigationCoordinatorTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D04B76581DE5B6D2009F1B9A /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -713,6 +779,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		33048BC121FA6F8A00B93597 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D04B765B1DE5B6D2009F1B9A /* Example */;
+			targetProxy = 33048BC021FA6F8A00B93597 /* PBXContainerItemProxy */;
+		};
 		D0A788CB21E25679002F34B2 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = D0A788C421E25679002F34B2 /* Coordinator */;
@@ -732,6 +803,53 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		33048BC221FA6F8A00B93597 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = ExampleTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.krin.ExampleTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.2;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Example.app/Example";
+			};
+			name = Debug;
+		};
+		33048BC321FA6F8A00B93597 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = ExampleTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.krin.ExampleTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.2;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Example.app/Example";
+			};
+			name = Release;
+		};
 		D04B766C1DE5B6D2009F1B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -947,6 +1065,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		33048BC421FA6F8A00B93597 /* Build configuration list for PBXNativeTarget "ExampleTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				33048BC221FA6F8A00B93597 /* Debug */,
+				33048BC321FA6F8A00B93597 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		D04B76571DE5B6D2009F1B9A /* Build configuration list for PBXProject "Coordinator" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Coordinator.xcodeproj/xcshareddata/xcschemes/Coordinator.xcscheme
+++ b/Coordinator.xcodeproj/xcshareddata/xcschemes/Coordinator.xcscheme
@@ -28,6 +28,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "33048BBA21FA6F8A00B93597"
+               BuildableName = "ExampleTests.xctest"
+               BlueprintName = "ExampleTests"
+               ReferencedContainer = "container:Coordinator.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <AdditionalOptions>
       </AdditionalOptions>

--- a/Coordinator/NavigationCoordinator.swift
+++ b/Coordinator/NavigationCoordinator.swift
@@ -109,24 +109,31 @@ open class NavigationCoordinator: Coordinator<UINavigationController>, UINavigat
 
 private extension NavigationCoordinator {
 	func didShowController(_ viewController: UIViewController, fromViewController: UIViewController?) {
-		guard let fromViewController = fromViewController else { return }
+        if let fromViewController = fromViewController {
+            guard viewControllers.contains(fromViewController) else { return }
+            guard let last = viewControllers.last, last === fromViewController else { return }
 
-		//	if this FROM controller is not in the Coordinator's internal list, ignore it
-		if !viewControllers.contains(fromViewController) { return }
+            if let index = viewControllers.firstIndex(of: viewController) {
+                let lastPosition = viewControllers.count - 1
+                viewControllers = Array(viewControllers.dropLast(lastPosition - index))
+                handlePopBack(to: viewController)
+            } else {
+                viewControllers.removeLast()
+                handlePopBack(to: last)
+            }
+        } else {
+            guard viewController !== viewControllers.last else { return }
+            guard let index = viewControllers.firstIndex(of: viewController) else { return }
 
-		//	check is this pop:
-		if let vc = self.viewControllers.last, vc === fromViewController {
-			//	it is pop. remove this controller from Coordinator's list
-			self.viewControllers.removeLast()
-			//	customization point for the NavigationCoordinator's subclass
-			//	to update its internal state on pop-back
-			self.handlePopBack(to: self.viewControllers.last)
-		}
+            let lastPosition = viewControllers.count - 1
+            viewControllers = Array(viewControllers.dropLast(lastPosition - index))
+            handlePopBack(to: viewController)
+        }
 
 		//	is there any controller left shown in this Coordinator?
-		if self.viewControllers.count == 0 {
+		if viewControllers.count == 0 {
 			//	inform the parent Coordinator that this child Coordinator has no more VCs
-			self.parent?.coordinatorDidFinish(self, completion: {})
+			parent?.coordinatorDidFinish(self, completion: {})
 			return
 		}
 	}

--- a/Coordinator/NavigationCoordinator.swift
+++ b/Coordinator/NavigationCoordinator.swift
@@ -17,7 +17,7 @@ open class NavigationCoordinator: Coordinator<UINavigationController>, UINavigat
 	///
 	///	It is strongly advised to *not* override this method, but it's allowed to do so in case you really need to.
 	///	What you likely want to override is `handlePopBack(to:)` method.
-	public func navigationController(_ navigationController: UINavigationController, didShow viewController: UIViewController, animated: Bool) {
+	open func navigationController(_ navigationController: UINavigationController, didShow viewController: UIViewController, animated: Bool) {
 		let fromViewController = navigationController.transitionCoordinator?.viewController(forKey: .from)
 		self.didShowController(viewController, fromViewController: fromViewController)
 	}

--- a/ExampleTests/Info.plist
+++ b/ExampleTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/ExampleTests/NavigationCoordinatorTests.swift
+++ b/ExampleTests/NavigationCoordinatorTests.swift
@@ -1,0 +1,100 @@
+//
+//  NavigationCoordinatorTests.swift
+//  Tests
+//
+//  Created by Krin-San on 1/22/19.
+//  Copyright © 2019 Radiant Tap. All rights reserved.
+//
+
+import XCTest
+import Coordinator
+
+class ReportingNavigationCoordinator: NavigationCoordinator {
+
+    var navigationChangeExpectation: XCTestExpectation?
+
+    override func navigationController(_ navigationController: UINavigationController, didShow viewController: UIViewController, animated: Bool) {
+        super.navigationController(navigationController, didShow: viewController, animated: animated)
+
+        navigationChangeExpectation?.fulfill()
+        navigationChangeExpectation = nil
+    }
+
+}
+
+class NavigationCoordinatorTests: XCTestCase {
+
+    let toPush = 3
+    let navigationController = UINavigationController()
+    var coordinator: ReportingNavigationCoordinator!
+
+    override func setUp() {
+        super.setUp()
+
+        continueAfterFailure = false
+
+        coordinator = ReportingNavigationCoordinator(rootViewController: navigationController)
+        UIApplication.shared.keyWindow?.rootViewController = navigationController
+        coordinator.start {}
+    }
+
+    func testPopAnimated() {
+        pushInitialControllers()
+        pop(animated: true)
+    }
+
+    func testPopNotAnimated() {
+        pushInitialControllers()
+        pop(animated: false)
+    }
+
+    func testPopToRootAnimated() {
+        pushInitialControllers()
+        popToRoot(animated: true)
+    }
+
+    func testPopToRootNotAnimated() {
+        pushInitialControllers()
+        popToRoot(animated: false)
+    }
+
+    func pushInitialControllers() {
+        for i in 0..<toPush {
+            coordinator.navigationChangeExpectation = expectation(description: "Controller #\(i) is shown")
+
+            let viewController = UIViewController()
+            viewController.title = "#\(i)"
+            coordinator.show(viewController)
+
+            waitForExpectations(timeout: 1)
+        }
+
+        XCTAssertEqual(coordinator.viewControllers, navigationController.viewControllers)
+        XCTAssertEqual(coordinator.viewControllers.count, toPush)
+        XCTAssertEqual(navigationController.viewControllers.count, toPush)
+    }
+
+    func pop(animated: Bool) {
+        coordinator.navigationChangeExpectation = expectation(description: "Controllers popped")
+        navigationController.popViewController(animated: animated)
+
+        waitForExpectations(timeout: 1)
+
+        XCTAssertEqual(coordinator.viewControllers, navigationController.viewControllers)
+        XCTAssertEqual(coordinator.viewControllers.count, toPush - 1)
+        XCTAssertEqual(navigationController.viewControllers.count, toPush - 1)
+    }
+
+    func popToRoot(animated: Bool) {
+        coordinator.navigationChangeExpectation = expectation(description: "Controllers popped")
+        let popped = navigationController.popToRootViewController(animated: animated)
+
+        waitForExpectations(timeout: 1)
+
+        XCTAssertEqual(coordinator.viewControllers, navigationController.viewControllers)
+        XCTAssertEqual(coordinator.viewControllers.count, 1)
+        XCTAssertEqual(navigationController.viewControllers.count, 1)
+        XCTAssertTrue(popped?.count == (toPush - 1))
+    }
+
+}


### PR DESCRIPTION
Fixes `NavigationCoordinator` issues mentioned in #19:
- handling of non-animated `popViewController` when `transitionCoordinator` doesn't exist
- handling of multiple controllers being popped _(animated or non-animated)_ either with `popToViewController` or with `popToRootViewController`

A simple Unit Test was added to cover forementioned 4 use cases. 3/4 tests are failing on current `master`.